### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,12 +13,12 @@ Button	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-update  KEYWORD2
-state   KEYWORD2
-setCallback KEYWORD2
+update	KEYWORD2
+state	KEYWORD2
+setCallback	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-BTN_CALLBACK    LITERAL1
+BTN_CALLBACK	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords