### PR TITLE
Change callback to allow for capturing lambada functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Declare a `ButtonDebouce` object with `pinNumber` and `timeMillis` to debounce a
 Example:
 
 ```
-void onButtonChange(int state) {
+void onButtonChange(const int state) {
   Serial.println("Changed: " + String(state));
 }
 ButtonDebounce button(3, 250); // PIN 3 with 250ms debounce time
@@ -25,11 +25,11 @@ button.setCallback(onButtonChange);
 Or - in a more asynchroneous style:
 
 ```
-void onButtonChange(int state) {
+void onButtonChange(const int state) {
   Serial.println("Changed: " + String(state));
 }
 ButtonDebounce button(3, 250); // PIN 3 with 250ms debounce time
-button.setCallback([](int state) {
+button.setCallback([](const int state) {
   Serial.println("Changed: " + String(state));
 });
 ```

--- a/examples/simple_callback/simple_callback.ino
+++ b/examples/simple_callback/simple_callback.ino
@@ -1,7 +1,7 @@
 #include <ButtonDebounce.h>
 
 ButtonDebounce button(10, 250);
-void buttonChanged(int state){
+void buttonChanged(const int state){
   Serial.println("Changed: " + String(state));
 }
 

--- a/src/ButtonDebounce.cpp
+++ b/src/ButtonDebounce.cpp
@@ -30,13 +30,13 @@ void ButtonDebounce::update(){
 
   _lastStateBtn = btnState;
 
-  if(this->callback) this->callback(_lastStateBtn);
+  if(this->_callBack) this->_callBack(_lastStateBtn);
 }
 
 int ButtonDebounce::state(){
   return _lastStateBtn;
 }
 
-void ButtonDebounce::setCallback(BTN_CALLBACK){
-  this->callback = callback;
+void ButtonDebounce::setCallback(ButtonCallback callback) { 
+  this->_callBack = callback;
 }

--- a/src/ButtonDebounce.h
+++ b/src/ButtonDebounce.h
@@ -8,7 +8,7 @@
 
 #include "Arduino.h"
 
-#define BTN_CALLBACK void (*callback)(int)
+typedef std::function<void(const int)> ButtonCallback;
 
 class ButtonDebounce{
   private:
@@ -17,13 +17,13 @@ class ButtonDebounce{
     unsigned long _lastDebounceTime;
     unsigned long _lastChangeTime;
     int _lastStateBtn;
-    BTN_CALLBACK;
+    ButtonCallback _callBack = NULL;
     bool isTimeToUpdate();
   public:
     ButtonDebounce(int pin, unsigned long delay);
     void update();
     int state();
-    void setCallback(BTN_CALLBACK);
+    void setCallback(ButtonCallback);
 };
 
 #endif


### PR DESCRIPTION
The callback function variable is now defined in a way that allows capturing lambada functions to be used as callback functions. Non lambada functions will continue to work as before. Also made the int parameter in the callback function const.